### PR TITLE
Fixed loose files crash

### DIFF
--- a/modloader/ModConfig.json
+++ b/modloader/ModConfig.json
@@ -1,7 +1,7 @@
 {
   "ModId": "p4gpc.modloader",
   "ModName": "Persona 4 Golden PC Mod Loader",
-  "ModAuthor": "TGE, Sewer56",
+  "ModAuthor": "TGE, Sewer56, Tekka",
   "ModVersion": "1.4.1",
   "ModDescription": "A mod loader for Persona 4 Golden (Steam)",
   "ModDll": "modloader.dll",

--- a/modloader/ModConfig.json
+++ b/modloader/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "p4gpc.modloader",
   "ModName": "Persona 4 Golden PC Mod Loader",
   "ModAuthor": "TGE, Sewer56",
-  "ModVersion": "1.4.0",
+  "ModVersion": "1.4.1",
   "ModDescription": "A mod loader for Persona 4 Golden (Steam)",
   "ModDll": "modloader.dll",
   "ModIcon": "Preview.png",

--- a/modloader/P4GPCModLoader.cs
+++ b/modloader/P4GPCModLoader.cs
@@ -36,7 +36,9 @@ namespace modloader
 
             // Init
             TrySetConsoleEncoding( EncodingCache.ShiftJIS );
-            mLogger.WriteLine( $"[modloader] Persona 4 Golden (Steam) Mod loader by TGE (2020) v{typeof(P4GPCModLoader).Assembly.GetName().Version}" );
+            var version = typeof(P4GPCModLoader).Assembly.GetName().Version.ToString();
+            version = version.Substring(0, version.LastIndexOf('.'));
+            mLogger.WriteLine( $"[modloader] Persona 4 Golden (Steam) Mod loader by TGE (2020) v{version}" );
             mNativeFunctions = NativeFunctions.GetInstance( hooks );
             mFileAccessServer = new FileAccessServer( hooks, mNativeFunctions );
 

--- a/modloader/Redirectors/Cpk/VirtualCpk.cs
+++ b/modloader/Redirectors/Cpk/VirtualCpk.cs
@@ -52,6 +52,8 @@ namespace modloader.Redirectors.Cpk
                 foreach ( var file in mod.Files )
                 {
                     var relPath = file.Substring( file.IndexOf( mod.LoadDirectory ) + mod.LoadDirectory.Length + 1 );
+                    if (relPath.IndexOf('\\') == -1)
+                        continue;
                     var cpkName = relPath.Substring( 0, relPath.IndexOf( '\\' ) );
                     if ( !cpkName.Equals( FileName, StringComparison.OrdinalIgnoreCase ) )
                         continue;

--- a/modloader/modloader.csproj
+++ b/modloader/modloader.csproj
@@ -5,7 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>WinExe</OutputType>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<OutputPath>$(RELOADEDIIMODS)\p4gpc.modloader</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
- Continue if relative path has no folder (caused exception when making substring from 0 to -1)
- Updated version number to 1.4.1 and removed extra 0 from logger output.