### PR TITLE
Change "Duration is not aligned properly" message from Warning to Info

### DIFF
--- a/modloader/Redirectors/Xact/VirtualWaveBankEntry.cs
+++ b/modloader/Redirectors/Xact/VirtualWaveBankEntry.cs
@@ -262,7 +262,7 @@ namespace modloader.Redirectors.Xact
                 }
 
                 if ( durationAligned > txth.Duration )
-                    mLogger.Warning( $"[{path} Duration is not aligned properly, it may not play correctly ingame!" );
+                    mLogger.Info( $"[{path} Duration is not aligned properly, it may not play correctly ingame!" );
 
                 Native->FlagsAndDuration.Duration.Set( ( uint )durationAligned );
             }


### PR DESCRIPTION
This message appears whenever P4G starts if any mod has an audio track that is not exactly the same duration as the track it is replacing. For BGM tracks, this message is useless as there is no playback issue with tracks of a different duration.

It is confusing users who believe the scary yellow text indicates something is wrong with their modding setup, and it has no value to anyone except creators who should be testing their mods before release anyway.